### PR TITLE
Add emojis before feature titles

### DIFF
--- a/App.js
+++ b/App.js
@@ -3,23 +3,23 @@ import { StyleSheet, Text, View, ScrollView, TouchableOpacity } from 'react-nati
 
 const FEATURES = [
   {
-    title: 'Chat humain-robot',
+    title: '🗣️ Chat humain-robot',
     description: 'Discutez en temps réel avec des utilisateurs humains et des robots intelligents.'
   },
   {
-    title: 'Réponses IA avancées',
+    title: '🤖 Réponses IA avancées',
     description: "Profitez d'une intelligence artificielle capable de générer des réponses pertinentes et naturelles."
   },
   {
-    title: 'Messagerie sécurisée',
+    title: '🔒 Messagerie sécurisée',
     description: 'Vos conversations sont chiffrées de bout en bout pour une confidentialité maximale.'
   },
   {
-    title: 'Support multilingue',
+    title: '🌐 Support multilingue',
     description: 'Communiquez dans plusieurs langues grâce à la traduction intégrée.'
   },
   {
-    title: 'Personnalisation du robot',
+    title: '🎨 Personnalisation du robot',
     description: 'Créez vos propres personnalités de robots pour des discussions sur mesure.'
   }
 ];

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Pour utiliser ce composant, intégrez-le dans un projet React Native existant ou
 Un fichier `index.js` est également fourni et se charge d'enregistrer l'application via `registerRootComponent`. Vérifiez que la propriété `main` du `package.json` pointe vers ce fichier.
 
 ## Fonctionnalités affichées
-- Chat humain-robot
-- Réponses IA avancées
-- Messagerie sécurisée
-- Support multilingue
-- Personnalisation du robot
+- 🗣️ Chat humain-robot
+- 🤖 Réponses IA avancées
+- 🔒 Messagerie sécurisée
+- 🌐 Support multilingue
+- 🎨 Personnalisation du robot
 
 ## Démarrage rapide
 


### PR DESCRIPTION
## Summary
- add descriptive emojis to feature titles in the React component
- mirror those emojis in the README features list

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad87da1e48330b4f7d9cde824511a